### PR TITLE
Move Quotation validation call from TaxJar to AWC

### DIFF
--- a/erpnext_taxjar/api.py
+++ b/erpnext_taxjar/api.py
@@ -1,73 +1,12 @@
 import traceback
 
 import pycountry
+import taxjar
 
 import frappe
-import taxjar
 from erpnext import get_default_company
 from frappe import _
 from frappe.contacts.doctype.address.address import get_company_address
-
-
-def get_client():
-	api_key = frappe.get_doc("TaxJar Settings", "TaxJar Settings").get_password("api_key")
-	client = taxjar.Client(api_key=api_key)
-	return client
-
-
-def set_sales_tax(doc, method):
-	if not doc.items:
-		return
-
-	# Allow skipping calculation of tax for dev environment
-	# if taxjar_calculate_tax isn't defined in site_config we assume
-	# we DO want to calculate tax all the time.
-	if not frappe.local.conf.get("taxjar_calculate_tax", 1):
-		return
-
-	if frappe.db.get_value("Customer", doc.customer, "exempt_from_sales_tax"):
-		for tax in doc.taxes:
-			if tax.description == "Sales Tax":
-				tax.tax_amount = 0
-				break
-
-		doc.run_method("calculate_taxes_and_totals")
-		return
-
-	client = get_client()
-	tax_account_head = frappe.db.get_single_value("TaxJar Settings", "tax_account_head")
-	tax_dict = get_tax_data(doc)
-
-	if not tax_dict:
-		taxes_list = []
-
-		for tax in doc.taxes:
-			if tax.account_head != tax_account_head:
-				taxes_list.append(tax)
-
-		setattr(doc, "taxes", taxes_list)
-		return
-
-	try:
-		taxdata = client.tax_for_order(tax_dict)
-	except taxjar.exceptions.TaxJarResponseError as err:
-		frappe.throw(_(sanitize_error_response(err)))
-		return
-
-	if "Sales Tax" in [tax.description for tax in doc.taxes]:
-		for tax in doc.taxes:
-			if tax.description == "Sales Tax":
-				tax.tax_amount = taxdata.amount_to_collect
-				break
-	elif taxdata.amount_to_collect > 0:
-		doc.append("taxes", {
-			"charge_type": "Actual",
-			"description": "Sales Tax",
-			"account_head": tax_account_head,
-			"tax_amount": taxdata.amount_to_collect
-		})
-
-		doc.run_method("calculate_taxes_and_totals")
 
 
 def create_transaction(doc, method):
@@ -77,7 +16,6 @@ def create_transaction(doc, method):
 	if not frappe.local.conf.get("taxjar_create_transactions", 1):
 		return
 
-	client = get_client()
 	sales_tax = 0
 
 	for tax in doc.taxes:
@@ -97,6 +35,8 @@ def create_transaction(doc, method):
 	tax_dict['sales_tax'] = sales_tax
 	tax_dict['amount'] = doc.total + tax_dict['shipping']
 
+	client = get_client()
+
 	try:
 		client.create_order(tax_dict)
 	except taxjar.exceptions.TaxJarResponseError as err:
@@ -110,49 +50,36 @@ def delete_transaction(doc, method):
 	client.delete_order(doc.name)
 
 
-def get_tax_data(doc):
+def get_client():
+	api_key = frappe.get_doc("TaxJar Settings", "TaxJar Settings").get_password("api_key")
+	client = taxjar.Client(api_key=api_key)
+	return client
+
+
+def get_shipping_address(doc):
 	company_address = get_company_address(get_default_company()).company_address
 	company_address = frappe.get_doc("Address", company_address)
+	shipping_address = None
 
 	if company_address:
 		if doc.shipping_address_name:
 			shipping_address = frappe.get_doc("Address", doc.shipping_address_name)
 		else:
 			shipping_address = company_address
-	else:
+
+	return shipping_address
+
+
+def get_tax_data(doc):
+	shipping_address = get_shipping_address(doc)
+
+	if not shipping_address:
 		return
-
-	if shipping_address.country != "United States":
-		return
-
-	us_states = pycountry.subdivisions.get(country_code='US')
-	us_states = [state.code.split('-')[1] for state in us_states]
-	address_state = shipping_address.get("state")
-
-	if address_state in us_states:
-		shipping_state = address_state
-	else:
-		try:
-			state = pycountry.subdivisions.lookup(address_state)
-		except LookupError:
-			error_message = """{} is not a valid US state!
-							Check for typos or enter the
-							2-letter ISO code for your state."""
-
-			frappe.throw(_(error_message.format(address_state)))
-			return
-		else:
-			shipping_state = state.code.split('-')[1]
 
 	taxjar_settings = frappe.get_single("TaxJar Settings")
 
-	client = get_client()
-
 	if not (taxjar_settings.api_key or taxjar_settings.tax_account_head):
 		return
-
-	api_key = frappe.get_doc("TaxJar Settings", "TaxJar Settings").get_password("api_key")
-	client = taxjar.Client(api_key=api_key)
 
 	shipping = 0
 
@@ -160,8 +87,11 @@ def get_tax_data(doc):
 		if tax.account_head == "Freight and Forwarding Charges - JA":
 			shipping = tax.tax_amount
 
+	shipping_state = validate_state(shipping_address)
+	country_code = frappe.get_value("Country", shipping_address.country, "code")
+
 	tax_dict = {
-		'to_country': 'US',
+		'to_country': country_code,
 		'to_zip': shipping_address.pincode,
 		'to_city': shipping_address.city,
 		'to_state': shipping_state,
@@ -183,7 +113,99 @@ def sanitize_error_response(response):
 		"sales_tax": "Sales Tax"
 	}
 
-	for r in sanitized_responses:
-		response = response.replace(r, sanitized_responses.get(r))
+	for k, v in sanitized_responses.items():
+		response = response.replace(k, v)
 
 	return response
+
+
+def set_sales_tax(doc, method):
+	if not doc.items:
+		return
+
+	# Allow skipping calculation of tax for dev environment
+	# if taxjar_calculate_tax isn't defined in site_config we assume
+	# we DO want to calculate tax all the time.
+	if not frappe.local.conf.get("taxjar_calculate_tax", 1):
+		return
+
+	if frappe.db.get_value("Customer", doc.customer, "exempt_from_sales_tax"):
+		for tax in doc.taxes:
+			if tax.description == "Sales Tax":
+				tax.tax_amount = 0
+				break
+
+		doc.run_method("calculate_taxes_and_totals")
+		return
+
+	tax_account_head = frappe.db.get_single_value(
+		"TaxJar Settings", "tax_account_head")
+	tax_dict = get_tax_data(doc)
+	taxdata = validate_tax_request(doc, tax_dict)
+
+	if not tax_dict:
+		taxes_list = []
+
+		for tax in doc.taxes:
+			if tax.account_head != tax_account_head:
+				taxes_list.append(tax)
+
+		setattr(doc, "taxes", taxes_list)
+		return
+
+	if "Sales Tax" in [tax.description for tax in doc.taxes]:
+		for tax in doc.taxes:
+			if tax.description == "Sales Tax":
+				tax.tax_amount = taxdata.amount_to_collect
+				break
+	elif taxdata.amount_to_collect > 0:
+		doc.append("taxes", {
+			"charge_type": "Actual",
+			"description": "Sales Tax",
+			"account_head": tax_account_head,
+			"tax_amount": taxdata.amount_to_collect
+		})
+
+		doc.run_method("calculate_taxes_and_totals")
+
+
+def validate_address(doc, address):
+	tax_dict = get_tax_data(doc)
+
+	validate_tax_request(doc, tax_dict)
+	validate_state(address)
+
+
+def validate_tax_request(doc, tax_dict):
+	client = get_client()
+
+	try:
+		taxdata = client.tax_for_order(tax_dict)
+	except taxjar.exceptions.TaxJarResponseError as err:
+		frappe.throw(_(sanitize_error_response(err)))
+	else:
+		return taxdata
+
+
+def validate_state(address):
+	country_code = frappe.get_value("Country", address.get("country"), "code")
+
+	states = pycountry.subdivisions.get(country_code=country_code)
+	states = [state.code.split('-')[1] for state in states]
+	address_state = address.get("state")
+
+	if address_state in states:
+		shipping_state = address_state
+	else:
+		try:
+			lookup_state = pycountry.subdivisions.lookup(address_state)
+		except LookupError:
+			error_message = """{} is not a valid state!
+							Check for typos or enter the
+							ISO code for your state."""
+
+			frappe.throw(_(error_message.format(address_state)))
+		else:
+			shipping_state = lookup_state.code.split('-')[1]
+
+	return shipping_state

--- a/erpnext_taxjar/api.py
+++ b/erpnext_taxjar/api.py
@@ -209,7 +209,7 @@ def validate_state(address):
 	except LookupError:
 		# If search fails, try again if the given state is an ISO code
 		if len(address_state) in range(1, 4):
-			country_code = get_country_code(address.get("country"))
+			country_code = frappe.db.get_value("Country", address.get("country"), "code")
 
 			states = pycountry.subdivisions.get(country_code=country_code.upper())
 			states = [state.code.split('-')[1] for state in states]  # PyCountry returns state code as {country_code}-{state-code} (e.g. US-FL)

--- a/erpnext_taxjar/api.py
+++ b/erpnext_taxjar/api.py
@@ -210,9 +210,7 @@ def validate_state(address):
 		try:
 			lookup_state = pycountry.subdivisions.lookup(address_state)
 		except LookupError:
-			error_message = """{} is not a valid state!
-							Check for typos or enter the
-							ISO code for your state."""
+			error_message = """{} is not a valid state! Check for typos or enter the ISO code for your state."""
 
 			frappe.throw(_(error_message.format(address_state)))
 		else:

--- a/erpnext_taxjar/api.py
+++ b/erpnext_taxjar/api.py
@@ -122,7 +122,7 @@ def get_tax_data(doc):
 	else:
 		return
 
-	if not shipping_address.country == "United States":
+	if shipping_address.country != "United States":
 		return
 
 	us_states = pycountry.subdivisions.get(country_code='US')
@@ -135,7 +135,7 @@ def get_tax_data(doc):
 		try:
 			state = pycountry.subdivisions.lookup(address_state)
 		except LookupError:
-			error_message = """{} is not a valid state!
+			error_message = """{} is not a valid US state!
 							Check for typos or enter the
 							2-letter ISO code for your state."""
 

--- a/erpnext_taxjar/api.py
+++ b/erpnext_taxjar/api.py
@@ -200,6 +200,9 @@ def validate_state(address):
 	states = [state.code.split('-')[1] for state in states] # PyCountry returns state code as {country_code}-{state-code} (e.g. US-FL)
 	address_state = address.get("state")
 
+	if address_state is not None:
+		address_state = address_state.upper()
+
 	# First try finding the state in PyCountry's database
 	# If it fails, try again by passing the string as is since
 	# PyCountry will accept the full state name,

--- a/erpnext_taxjar/hooks.py
+++ b/erpnext_taxjar/hooks.py
@@ -26,7 +26,7 @@ doc_events = {
 	}
 }
 
-taxjar_api = [
+tax_api = [
 	"erpnext_taxjar.api.set_sales_tax"
 ]
 

--- a/erpnext_taxjar/hooks.py
+++ b/erpnext_taxjar/hooks.py
@@ -16,18 +16,21 @@ app_license = "MIT"
 
 
 doc_events = {
-	"Sales Order" : {
-		"validate" : "erpnext_taxjar.api.set_sales_tax"
+	"Quotation": {
+		"validate": "erpnext_taxjar.api.set_sales_tax"
 	},
-	"Sales Invoice" : {
-		"validate" : "erpnext_taxjar.api.set_sales_tax",
-		"on_submit" : "erpnext_taxjar.api.create_transaction",
-		"on_cancel" : "erpnext_taxjar.api.delete_transaction"
+	"Sales Order": {
+		"validate": "erpnext_taxjar.api.set_sales_tax"
+	},
+	"Sales Invoice": {
+		"validate": "erpnext_taxjar.api.set_sales_tax",
+		"on_submit": "erpnext_taxjar.api.create_transaction",
+		"on_cancel": "erpnext_taxjar.api.delete_transaction"
 	}
 }
 
-tax_api = [
-	"erpnext_taxjar.api.set_sales_tax"
+awc_address_validation = [
+	"erpnext_taxjar.api.validate_address"
 ]
 
 # include js, css files in header of desk.html

--- a/erpnext_taxjar/hooks.py
+++ b/erpnext_taxjar/hooks.py
@@ -16,19 +16,19 @@ app_license = "MIT"
 
 
 doc_events = {
-	"Quotation" : {
-		"validate": "erpnext_taxjar.api.set_sales_tax"
-	},
 	"Sales Order" : {
 		"validate" : "erpnext_taxjar.api.set_sales_tax"
 	},
-    "Sales Invoice" : {
+	"Sales Invoice" : {
 		"validate" : "erpnext_taxjar.api.set_sales_tax",
 		"on_submit" : "erpnext_taxjar.api.create_transaction",
 		"on_cancel" : "erpnext_taxjar.api.delete_transaction"
 	}
 }
 
+taxjar_api = [
+	"erpnext_taxjar.api.set_sales_tax"
+]
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/erpnext_taxjar/css/erpnext_taxjar.css"


### PR DESCRIPTION
Connected to https://github.com/DigiThinkIT/awesome_cart/pull/233

---

If a wrong address is entered, TaxJar (or PyCountry) throws an error before a Shipment API call is made.

---

![image](https://user-images.githubusercontent.com/13396535/33882148-311de3a2-df5d-11e7-8d1a-b3985cb6a9d6.png)